### PR TITLE
Add CI workflow to release to charmhub on push to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,79 @@
+name: Release to dpe/edge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire around 2023-09-23
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run tests
+        run: tox -e unit
+
+  integration-test-microk8s:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run integration tests
+        run: tox -e integration
+
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs:
+      - lib-check
+      - lint
+      - unit-test
+      - integration-test-microk8s
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@2.0.0-rc
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@2.0.0-rc
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "dpe/edge"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
-  integration-test-microk8s:
+  integration-test:
     name: Integration tests
     runs-on: ubuntu-latest
     steps:
@@ -61,7 +61,7 @@ jobs:
       - lib-check
       - lint
       - unit-test
-      - integration-test-microk8s
+      - integration-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Issue
We do not have a CI workflow that will auto-release the charm to charmhub upon a push to the main branch. We have acquired a charmhub token from the openstack team that will allow us to publish the charm to [mysql-router](https://charmhub.io/mysql-router) on the `dpe` track.

## Solution
Add a CI workflow to auto-release the charm to the `dpe/edge` channel upon a push to the main branch

## Release Notes
Add CI workflow to release to charmhub on push to main
