### PR TITLE
Change name of charm to correctly upload to charmhub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: Tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-name: mysqlrouter
+name: mysql-router
 display-name: MySQL Router
 maintainers:
   - Shayan Patel <shayan.patel@canonical.com>


### PR DESCRIPTION
## Issue
1. The name of the charm is `mysqlrouter` and thus cannot be uploaded to `mysql-router` on charmhub
2. The workflows in `ci.yaml` gets run upon push to main. The jobs in this workflow are duplicated in `release.yaml`

## Solution
1. Change the name of the charm to `mysql-router`
2. Remove the duplicate workflow jobs from `ci.yaml`

## Release Notes
Change name of charm to correctly upload to charmhub
