### PR TITLE
Allow for relations to be formed in any order

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -23,18 +24,22 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
-  integration-test-shared-db:
-    name: Integration tests for the shared db relation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run integration tests
-        run: tox -e integration-shared-db
+
+  # TODO: uncomment when the following bug is resolved:
+  # https://bugs.launchpad.net/charm-keystone/+bug/1990243
+  # integration-test-shared-db:
+  #   name: Integration tests for the shared db relation
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Setup operator environment
+  #       uses: charmed-kubernetes/actions-operator@main
+  #       with:
+  #         provider: lxd
+  #     - name: Run integration tests
+  #       run: tox -e integration-shared-db
+
   integration-test-database:
     name: Integration tests for the database relation
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,18 +42,20 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
-  integration-test-shared-db:
-    name: Integration tests for the shared db relation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run integration tests
-        run: tox -e integration-shared-db
+  # TODO: Uncomment when the following bug is resolved
+  # https://bugs.launchpad.net/charm-keystone/+bug/1990243
+  # integration-test-shared-db:
+  #   name: Integration tests for the shared db relation
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Setup operator environment
+  #       uses: charmed-kubernetes/actions-operator@main
+  #       with:
+  #         provider: lxd
+  #     - name: Run integration tests
+  #       run: tox -e integration-shared-db
 
   integration-test-database:
     name: Integration tests for the database relation
@@ -74,7 +76,7 @@ jobs:
       - lib-check
       - lint
       - unit-test
-      - integration-test-shared-db
+      # - integration-test-shared-db  # Uncomment when https://bugs.launchpad.net/charm-keystone/+bug/1990243 is resolved
       - integration-test-database
     runs-on: ubuntu-latest
     steps:

--- a/src/relations/database_requires.py
+++ b/src/relations/database_requires.py
@@ -98,7 +98,12 @@ class DatabaseRequiresRelation(Object):
     # =======================
 
     def _on_database_requires_relation_joined(self, event: RelationJoinedEvent) -> None:
-        """Handle the backend-database relation joined event."""
+        """Handle the backend-database relation joined event.
+
+        Waits until the database (provides) relation with the application is formed
+        before triggering the database_requires relation joined event (which will
+        request the database).
+        """
         if not self.charm.unit.is_leader():
             return
 

--- a/src/relations/database_requires.py
+++ b/src/relations/database_requires.py
@@ -36,7 +36,7 @@ class DatabaseRequiresRelation(Object):
 
         self.framework.observe(
             self.charm.on[DATABASE_REQUIRES_RELATION].relation_joined,
-            self._on_database_requires_relation_joined
+            self._on_database_requires_relation_joined,
         )
 
         shared_db_data = self._get_shared_db_data()

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -44,7 +44,7 @@ async def test_database_relation(ops_test: OpsTest) -> None:
         ),
     )
 
-    mysql_app, application_app = applications[0], applications[1], applications[2]
+    mysql_app, application_app = applications[0], applications[2]
 
     await ops_test.model.relate(
         f"{MYSQL_ROUTER_APP_NAME}:backend-database", f"{MYSQL_APP_NAME}:database"


### PR DESCRIPTION
## Issue
Currently, relations must formed in a specific order (the relation between `application<->mysqlrouter` first, and then the relation between `mysqlrouter<->mysql`). If we form the relations in reverse order, we miss the `backend-database-joined` event (which is where the database+user creation is requested).

## Solution
Add an event handler for the `backend-database-joined` event where we will defer until the relation with the application (provides relation) is formed, after which we can safely request the database+user creation (by calling the event handler in data-platform-libs explicitly).

## Release Notes
Allow for relations to be formed in any order
