### PR TITLE
Escape database identifiers with backticks

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,10 +2,6 @@
 # See LICENSE file for licensing details.
 
 type: charm
-parts:
-  charm:
-    charm-binary-python-packages:
-      - mysql-connector-python==8.0.30
 bases:
   - build-on:
       - name: "ubuntu"
@@ -13,3 +9,7 @@ bases:
     run-on:
       - name: "ubuntu"
         channel: "20.04"
+parts:
+  charm:
+    charm-binary-python-packages:
+      - mysql-connector-python==8.0.30

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,3 +27,5 @@ requires:
 peers:
   mysql-router:
     interface: mysql-router-peers
+series:
+  - focal

--- a/src/mysql_router_helpers.py
+++ b/src/mysql_router_helpers.py
@@ -200,8 +200,8 @@ class MySQLRouter:
             )
             cursor = connection.cursor()
 
-            cursor.execute(f"CREATE USER '{username}'@'{hostname}' IDENTIFIED BY '{password}'")
-            cursor.execute(f"GRANT ALL PRIVILEGES ON {database}.* TO '{username}'@'{hostname}'")
+            cursor.execute(f"CREATE USER `{username}`@`{hostname}` IDENTIFIED BY '{password}'")
+            cursor.execute(f"GRANT ALL PRIVILEGES ON `{database}`.* TO `{username}`@`{hostname}`")
 
             cursor.close()
             connection.close()

--- a/tests/integration/application-charm/metadata.yaml
+++ b/tests/integration/application-charm/metadata.yaml
@@ -14,3 +14,6 @@ requires:
 peers:
   application-peers:
     interface: app-peers
+
+series:
+  - focal

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -39,7 +39,7 @@ class ApplicationCharm(CharmBase):
 
         self.framework.observe(self.on.start, self._on_start)
 
-        self.database_name = f"{self.app.name.replace('-', '_')}_test_database"
+        self.database_name = f"{self.app.name}-test-database"
         self.database_requires = DatabaseRequires(self, REMOTE, self.database_name)
         self.framework.observe(
             self.database_requires.on.database_created, self._on_database_created

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -72,7 +72,7 @@ class ApplicationCharm(CharmBase):
             with MySQLConnector(database_config) as cursor:
                 cursor.execute(
                     (
-                        f"SELECT data FROM {self.database_name}.app_data "
+                        f"SELECT data FROM `{self.database_name}`.app_data "
                         f"WHERE data = '{inserted_value}'"
                     )
                 )
@@ -119,7 +119,7 @@ class ApplicationCharm(CharmBase):
         """Creates a test table in the database."""
         cursor.execute(
             (
-                f"CREATE TABLE IF NOT EXISTS {self.database_name}.app_data("
+                f"CREATE TABLE IF NOT EXISTS `{self.database_name}`.app_data("
                 "id SMALLINT NOT NULL AUTO_INCREMENT, "
                 "data VARCHAR(255), "
                 "PRIMARY KEY (id))"
@@ -129,7 +129,7 @@ class ApplicationCharm(CharmBase):
     def _insert_test_data(self, cursor, random_value: str) -> None:
         """Inserts the provided random value into the test table in the database."""
         cursor.execute(
-            f"INSERT INTO {self.database_name}.app_data(data) VALUES(%s)",
+            f"INSERT INTO `{self.database_name}`.app_data(data) VALUES(%s)",
             (random_value,),
         )
 

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -87,7 +87,7 @@ async def test_database_relation(ops_test: OpsTest) -> None:
     server_config_credentials = await get_server_config_credentials(mysql_unit)
 
     select_inserted_data_sql = (
-        f"SELECT data FROM application_test_database.app_data WHERE data = '{inserted_data}'",
+        f"SELECT data FROM `application-test-database`.app_data WHERE data = '{inserted_data}'",
     )
     selected_data = await execute_queries_on_unit(
         mysql_unit_address,


### PR DESCRIPTION
## Issue
We are not escaping database identifiers (like usernames, hostnames and databases) when creating a user in mysqlrouter. This is leading to a misleading error surfaced in [this jira ticket](https://warthogs.atlassian.net/browse/DPE-909).

## Solution
Escape identifiers with backticks.

## Release Notes
Escape database identifiers with backticks
