### PR TITLE
Enable GR notifications

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
@@ -36,7 +36,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v3
   #     - name: Setup operator environment
   #       uses: charmed-kubernetes/actions-operator@main
   #       with:
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/src/mysql_router_helpers.py
+++ b/src/mysql_router_helpers.py
@@ -114,6 +114,7 @@ class MySQLRouter:
         name,
         db_host,
         port,
+        force=False,
     ) -> None:
         """Bootstrap MySQLRouter and register the service with systemd.
 
@@ -130,7 +131,7 @@ class MySQLRouter:
         # server_ssl_mode is set to enforce unix_socket connections to be established
         # via encryption (see more at
         # https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html)
-        bootstrap_mysqlrouter_command = (
+        bootstrap_mysqlrouter_command = [
             "sudo",
             "/usr/bin/mysqlrouter",
             "--user",
@@ -148,7 +149,11 @@ class MySQLRouter:
             f"{port}",
             "--conf-set-option",
             "DEFAULT.server_ssl_mode=PREFERRED",
-        )
+            "--conf-use-gr-notifications",
+        ]
+
+        if force:
+            bootstrap_mysqlrouter_command.append("--force")
 
         try:
             subprocess.check_output(bootstrap_mysqlrouter_command, stderr=subprocess.STDOUT)

--- a/src/mysql_router_helpers.py
+++ b/src/mysql_router_helpers.py
@@ -124,6 +124,7 @@ class MySQLRouter:
             name: The name of application that will use mysqlrouter
             db_host: The hostname of the database to connect to
             port: The port at which to bootstrap mysqlrouter to
+            force: Overwrite existing config if any
 
         Raises:
             MySQLRouterBootstrapError - if there is an issue bootstrapping MySQLRouter

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,15 +1,19 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import unittest
 from unittest.mock import patch
 
-from ops.model import BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import MySQLRouterOperatorCharm
-from constants import PEER
-from mysql_router_helpers import MySQLRouterInstallAndConfigureError
+from constants import MYSQL_ROUTER_REQUIRES_DATA, PEER
+from mysql_router_helpers import (
+    MySQLRouterBootstrapError,
+    MySQLRouterInstallAndConfigureError,
+)
 
 
 class TestCharm(unittest.TestCase):
@@ -76,3 +80,56 @@ class TestCharm(unittest.TestCase):
         self.charm.on.install.emit()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+    @patch("charm.DatabaseProvidesRelation._get_related_app_name")
+    @patch("charm.MySQLRouterOperatorCharm._get_secret")
+    @patch("mysql_router_helpers.MySQLRouter.bootstrap_and_start_mysql_router")
+    def test_on_upgrade_charm(
+        self, bootstrap_and_start_mysql_router, get_secret, get_related_app_name
+    ):
+        self.charm.unit.status = ActiveStatus()
+        get_secret.return_value = "s3kr1t"
+        get_related_app_name.return_value = "testapp"
+        self.charm.app_peer_data[MYSQL_ROUTER_REQUIRES_DATA] = json.dumps(
+            {
+                "username": "test_user",
+                "endpoints": "10.10.0.1:3306,10.10.0.2:3306",
+            }
+        )
+        self.charm.on.upgrade_charm.emit()
+
+        self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
+        bootstrap_and_start_mysql_router.assert_called_with(
+            "test_user", "s3kr1t", "testapp", "10.10.0.1", "3306", True
+        )
+
+    @patch("mysql_router_helpers.MySQLRouter.bootstrap_and_start_mysql_router")
+    def test_on_upgrade_charm_waiting(self, bootstrap_and_start_mysql_router):
+        self.charm.unit.status = WaitingStatus()
+        self.charm.on.upgrade_charm.emit()
+
+        self.assertTrue(isinstance(self.harness.model.unit.status, WaitingStatus))
+        bootstrap_and_start_mysql_router.assert_not_called()
+
+    @patch("charm.DatabaseProvidesRelation._get_related_app_name")
+    @patch("charm.MySQLRouterOperatorCharm._get_secret")
+    @patch("mysql_router_helpers.MySQLRouter.bootstrap_and_start_mysql_router")
+    def test_on_upgrade_charm_error(
+        self, bootstrap_and_start_mysql_router, get_secret, get_related_app_name
+    ):
+        bootstrap_and_start_mysql_router.side_effect = MySQLRouterBootstrapError()
+        get_secret.return_value = "s3kr1t"
+        get_related_app_name.return_value = "testapp"
+        self.charm.unit.status = ActiveStatus()
+        self.charm.app_peer_data[MYSQL_ROUTER_REQUIRES_DATA] = json.dumps(
+            {
+                "username": "test_user",
+                "endpoints": "10.10.0.1:3306,10.10.0.2:3306",
+            }
+        )
+        self.charm.on.upgrade_charm.emit()
+
+        self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+        bootstrap_and_start_mysql_router.assert_called_with(
+            "test_user", "s3kr1t", "testapp", "10.10.0.1", "3306", True
+        )

--- a/tests/unit/test_mysql_router_helpers.py
+++ b/tests/unit/test_mysql_router_helpers.py
@@ -1,0 +1,137 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from subprocess import STDOUT, CalledProcessError
+from unittest.mock import patch
+
+from charms.operator_libs_linux.v1.systemd import SystemdError
+
+from constants import MYSQL_ROUTER_SERVICE_NAME
+from mysql_router_helpers import MySQLRouter, MySQLRouterBootstrapError
+
+bootstrap_cmd = [
+    "sudo",
+    "/usr/bin/mysqlrouter",
+    "--user",
+    "mysql",
+    "--name",
+    "testapp",
+    "--bootstrap",
+    "test_user:qweqwe@10.10.0.1",
+    "--directory",
+    "/var/lib/mysql/testapp",
+    "--conf-use-sockets",
+    "--conf-bind-address",
+    "127.0.0.1",
+    "--conf-base-port",
+    "3306",
+    "--conf-set-option",
+    "DEFAULT.server_ssl_mode=PREFERRED",
+    "--conf-use-gr-notifications",
+]
+
+
+class TestMysqlRouterHelpers(unittest.TestCase):
+    @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
+    @patch("mysql_router_helpers.systemd")
+    @patch("mysql_router_helpers.subprocess.check_output")
+    def test_bootstrap_and_start_mysql_router(self, check_output, systemd, render_and_copy):
+        MySQLRouter.bootstrap_and_start_mysql_router(
+            "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
+        )
+        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+        render_and_copy.assert_called_with("testapp")
+        systemd.daemon_reload.assert_called_with()
+        systemd.service_start.assert_called_with(MYSQL_ROUTER_SERVICE_NAME)
+
+    @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
+    @patch("mysql_router_helpers.systemd")
+    @patch("mysql_router_helpers.subprocess.check_output")
+    def test_bootstrap_and_start_mysql_router_force(self, check_output, systemd, render_and_copy):
+        MySQLRouter.bootstrap_and_start_mysql_router(
+            "test_user", "qweqwe", "testapp", "10.10.0.1", "3306", True
+        )
+        check_output.assert_called_with(bootstrap_cmd + ["--force"], stderr=STDOUT)
+        render_and_copy.assert_called_with("testapp")
+        systemd.daemon_reload.assert_called_with()
+        systemd.service_start.assert_called_with(MYSQL_ROUTER_SERVICE_NAME)
+
+    @patch("mysql_router_helpers.logger")
+    @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
+    @patch("mysql_router_helpers.systemd")
+    @patch("mysql_router_helpers.subprocess.check_output")
+    def test_bootstrap_and_start_mysql_router_subprocess_error(
+        self, check_output, systemd, render_and_copy, logger
+    ):
+        e = CalledProcessError(1, bootstrap_cmd)
+        check_output.side_effect = e
+        with self.assertRaises(MySQLRouterBootstrapError):
+            MySQLRouter.bootstrap_and_start_mysql_router(
+                "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
+            )
+        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+        render_and_copy.assert_not_called()
+        systemd.daemon_reload.assert_not_called()
+        systemd.service_start.assert_not_called()
+        logger.exception.assert_called_with("Failed to bootstrap mysqlrouter", exc_info=e)
+
+    @patch("mysql_router_helpers.logger")
+    @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
+    @patch("mysql_router_helpers.systemd.service_start")
+    @patch("mysql_router_helpers.systemd.daemon_reload")
+    @patch("mysql_router_helpers.subprocess.check_output")
+    def test_bootstrap_and_start_mysql_router_systemd_error(
+        self, check_output, daemon_reload, service_start, render_and_copy, logger
+    ):
+        e = SystemdError()
+        daemon_reload.side_effect = e
+        with self.assertRaises(MySQLRouterBootstrapError):
+            MySQLRouter.bootstrap_and_start_mysql_router(
+                "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
+            )
+        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+        render_and_copy.assert_called_with("testapp")
+        daemon_reload.assert_called_with()
+        service_start.assert_not_called()
+        logger.exception.assert_called_with(
+            "Failed to set up mysqlrouter as a systemd service", exc_info=e
+        )
+
+    @patch("mysql_router_helpers.logger")
+    @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
+    @patch("mysql_router_helpers.systemd.service_start")
+    @patch("mysql_router_helpers.systemd.daemon_reload")
+    @patch("mysql_router_helpers.subprocess.check_output")
+    def test_bootstrap_and_start_mysql_router_no_daemon_reload(
+        self, check_output, daemon_reload, service_start, render_and_copy, logger
+    ):
+        daemon_reload.return_value = False
+        with self.assertRaises(MySQLRouterBootstrapError):
+            MySQLRouter.bootstrap_and_start_mysql_router(
+                "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
+            )
+        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+        render_and_copy.assert_called_with("testapp")
+        daemon_reload.assert_called_with()
+        service_start.assert_not_called()
+        logger.exception.assert_called_with("Failed to load the mysqlrouter systemd service")
+
+    @patch("mysql_router_helpers.logger")
+    @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
+    @patch("mysql_router_helpers.systemd.service_start")
+    @patch("mysql_router_helpers.systemd.daemon_reload")
+    @patch("mysql_router_helpers.subprocess.check_output")
+    def test_bootstrap_and_start_mysql_router_no_service_start(
+        self, check_output, daemon_reload, service_start, render_and_copy, logger
+    ):
+        service_start.return_value = False
+        with self.assertRaises(MySQLRouterBootstrapError):
+            MySQLRouter.bootstrap_and_start_mysql_router(
+                "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
+            )
+        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+        render_and_copy.assert_called_with("testapp")
+        daemon_reload.assert_called_with()
+        service_start.assert_called_with(MYSQL_ROUTER_SERVICE_NAME)
+        logger.exception.assert_called_with("Failed to start the mysqlrouter systemd service")

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==5.0.4
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
## Issue
* [DPE-913](https://warthogs.atlassian.net/browse/DPE-913)
* Group Replication notifications are disabled

## Solution
* Enable GR notifications config when bootstrapping mysql-router

## Context
* Added gr notification config flag to the bootstrap call
* Add handler for upgrade charm handler to reconfigure an already running charm
* Updated github checkout action version

## Release Notes
* Enable Group Replication notifications

## Testing
* Added unit tests for `_on_upgrade_charm`
* Added unit tests for `bootstrap_and_start_mysql_router`
