### PR TITLE
Disable charmcraft destructive mode, bump versions, add CodeCov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox run -e unit
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3
 
   lib-check:
     name: Check libraries

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,21 @@ jobs:
       - name: Run tests
         run: tox run -e unit
 
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@2.2.2
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire around 2023-09-23
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   build:
     name: Build charms
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
@@ -55,6 +70,7 @@ jobs:
           - integration-database
     name: ${{ matrix.tox-environments }}
     needs:
+      - lib-check
       - lint
       - unit-test
       - build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,11 +12,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@1.0.3
+        uses: canonical/charming-actions/check-libraries@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire around 2023-09-23
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -35,15 +35,16 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0-rc
-        id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc
+        uses: canonical/charming-actions/upload-charm@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "dpe/edge"
+          destructive-mode: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,30 +6,14 @@ on:
       - main
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.2.2
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire around 2023-09-23
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   ci-tests:
-    needs:
-      - lib-check
+    name: Tests
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   release-to-charmhub:
     name: Release to CharmHub
     needs:
-      - lib-check
       - ci-tests
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ build/
 *.charm
 .tox/
 .coverage
+coverage.xml
 __pycache__/
 *.py[cod]

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,4 +12,4 @@ bases:
 parts:
   charm:
     charm-binary-python-packages:
-      - mysql-connector-python==8.0.30
+      - mysql-connector-python==8.0.32

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ commands =
     coverage run --source={[vars]src_path} \
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     coverage report
+    coverage xml
 
 [testenv:integration-shared-db]
 description = Run shared db relation integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==5.0.4
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
-    mysql-connector-python==8.0.30
+    mysql-connector-python==8.0.32
     Jinja2==3.1.2
     pytest
     coverage[toml]


### PR DESCRIPTION
## Issue
The operator was not updated in store for a long:
 https://charmhub.io/mysql-router?channel=dpe/edge (last update Nov 25, 2022)
While several important commits are available in git for publishing.

## Solution
We have to disable charmcraft destructive mode to build focal on jammy GH runners.
While we are here, let's update all known dependencies and pinning to be up-2-date.
