### PR TITLE
Remove leftover line from release.yaml to make GH CI/CD happy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,6 @@ jobs:
           fetch-depth: 0
       - name: Setup LXD
         uses: canonical/setup-lxd@main
-      - name: Select charmhub channel
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.2.2
         with:


### PR DESCRIPTION
## Issue
The previous commit a06334465 had a [typo](https://github.com/canonical/mysql-router-operator/blob/a06334465a7b17e3f1672b49d5381c0da4f4f881/.github/workflows/release.yaml#L27) which makes GItHub sad:
```
Error: .github#L1
every step must define a `uses` or `run` key
```

## Solution
Removing unnecessary line.