### PR TITLE
Fix mysqlrouter application directory permissions to enable access to socket file from other users

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -142,7 +142,7 @@ class MySQLRouterOperatorCharm(CharmBase):
                     related_app_name,
                     requires_data["endpoints"].split(",")[0].split(":")[0],
                     "3306",
-                    True,
+                    force=True,
                 )
             except MySQLRouterBootstrapError:
                 self.unit.status = BlockedStatus("Failed to bootstrap mysqlrouter")

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,8 +6,6 @@
 MYSQL_ROUTER_APT_PACKAGE = "mysql-router"
 MYSQL_ROUTER_GROUP = "mysql"
 MYSQL_ROUTER_USER = "mysql"
-ROOT_USER = "root"
-ROOT_GROUP = "root"
 MYSQL_HOME_DIRECTORY = "/var/lib/mysql"
 PEER = "mysql-router-peers"
 DATABASE_REQUIRES_RELATION = "backend-database"

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,6 +6,8 @@
 MYSQL_ROUTER_APT_PACKAGE = "mysql-router"
 MYSQL_ROUTER_GROUP = "mysql"
 MYSQL_ROUTER_USER = "mysql"
+ROOT_USER = "root"
+ROOT_GROUP = "root"
 MYSQL_HOME_DIRECTORY = "/var/lib/mysql"
 PEER = "mysql-router-peers"
 DATABASE_REQUIRES_RELATION = "backend-database"

--- a/src/mysql_router_helpers.py
+++ b/src/mysql_router_helpers.py
@@ -22,8 +22,6 @@ from constants import (
     MYSQL_ROUTER_SYSTEMD_DIRECTORY,
     MYSQL_ROUTER_UNIT_TEMPLATE,
     MYSQL_ROUTER_USER,
-    ROOT_GROUP,
-    ROOT_USER,
 )
 
 logger = logging.getLogger(__name__)
@@ -133,6 +131,7 @@ class MySQLRouter:
         # via encryption (see more at
         # https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html)
         bootstrap_mysqlrouter_command = [
+            "sudo",
             "/usr/bin/mysqlrouter",
             "--user",
             MYSQL_ROUTER_USER,
@@ -158,17 +157,9 @@ class MySQLRouter:
             bootstrap_mysqlrouter_command.append("--force")
 
         try:
-            subprocess.run(
-                bootstrap_mysqlrouter_command,
-                user=ROOT_USER,
-                group=ROOT_GROUP,
-            )
+            subprocess.run(bootstrap_mysqlrouter_command)
 
-            subprocess.run(
-                f"chmod 755 {MYSQL_HOME_DIRECTORY}/{name}".split(),
-                user=ROOT_USER,
-                group=ROOT_GROUP,
-            )
+            subprocess.run(f"sudo chmod 755 {MYSQL_HOME_DIRECTORY}/{name}".split())
 
             MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file(name)
 

--- a/src/mysql_router_helpers.py
+++ b/src/mysql_router_helpers.py
@@ -22,6 +22,8 @@ from constants import (
     MYSQL_ROUTER_SYSTEMD_DIRECTORY,
     MYSQL_ROUTER_UNIT_TEMPLATE,
     MYSQL_ROUTER_USER,
+    ROOT_GROUP,
+    ROOT_USER,
 )
 
 logger = logging.getLogger(__name__)
@@ -87,9 +89,7 @@ class MySQLRouter:
 
                 os.chown(MYSQL_HOME_DIRECTORY, user_id, group_id)
         except Exception as e:
-            logger.exception(
-                f"Failed to install the {MYSQL_ROUTER_APT_PACKAGE} apt package.", exc_info=e
-            )
+            logger.exception(f"Failed to install the {MYSQL_ROUTER_APT_PACKAGE} apt package.")
             raise MySQLRouterInstallAndConfigureError(e.stderr)
 
     @staticmethod
@@ -133,7 +133,6 @@ class MySQLRouter:
         # via encryption (see more at
         # https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html)
         bootstrap_mysqlrouter_command = [
-            "sudo",
             "/usr/bin/mysqlrouter",
             "--user",
             MYSQL_ROUTER_USER,
@@ -159,23 +158,37 @@ class MySQLRouter:
             bootstrap_mysqlrouter_command.append("--force")
 
         try:
-            subprocess.check_output(bootstrap_mysqlrouter_command, stderr=subprocess.STDOUT)
+            subprocess.run(
+                bootstrap_mysqlrouter_command,
+                user=ROOT_USER,
+                group=ROOT_GROUP,
+            )
+
+            subprocess.run(
+                f"chmod 755 {MYSQL_HOME_DIRECTORY}/{name}".split(),
+                user=ROOT_USER,
+                group=ROOT_GROUP,
+            )
+
             MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file(name)
 
             if not systemd.daemon_reload():
-                logger.exception("Failed to load the mysqlrouter systemd service")
-                raise MySQLRouterBootstrapError("Failed to load mysqlrouter systemd service")
+                error_message = "Failed to load the mysqlrouter systemd service"
+                logger.exception(error_message)
+                raise MySQLRouterBootstrapError(error_message)
 
             systemd.service_start(MYSQL_ROUTER_SERVICE_NAME)
             if not MySQLRouter.is_mysqlrouter_running():
-                logger.exception("Failed to start the mysqlrouter systemd service")
-                raise MySQLRouterBootstrapError("Failed to start the mysqlrouter systemd service")
+                error_message = "Failed to start the mysqlrouter systemd service"
+                logger.exception(error_message)
+                raise MySQLRouterBootstrapError(error_message)
         except subprocess.CalledProcessError as e:
-            logger.exception("Failed to bootstrap mysqlrouter", exc_info=e)
+            logger.exception("Failed to bootstrap mysqlrouter")
             raise MySQLRouterBootstrapError(e.stderr)
-        except systemd.SystemdError as e:
-            logger.exception("Failed to set up mysqlrouter as a systemd service", exc_info=e)
-            raise MySQLRouterBootstrapError("Failed to set up mysqlrouter as a systemd service")
+        except systemd.SystemdError:
+            error_message = "Failed to set up mysqlrouter as a systemd service"
+            logger.exception(error_message)
+            raise MySQLRouterBootstrapError(error_message)
 
     @staticmethod
     def is_mysqlrouter_running() -> bool:
@@ -214,5 +227,5 @@ class MySQLRouter:
             cursor.close()
             connection.close()
         except mysql.connector.Error as e:
-            logger.exception("Failed to create user scoped to a database", exc_info=e)
+            logger.exception("Failed to create user scoped to a database")
             raise MySQLRouterCreateUserWithDatabasePrivilegesError(e.msg)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -101,7 +101,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
         bootstrap_and_start_mysql_router.assert_called_with(
-            "test_user", "s3kr1t", "testapp", "10.10.0.1", "3306", True
+            "test_user", "s3kr1t", "testapp", "10.10.0.1", "3306", force=True
         )
 
     @patch("mysql_router_helpers.MySQLRouter.bootstrap_and_start_mysql_router")
@@ -132,5 +132,5 @@ class TestCharm(unittest.TestCase):
 
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
         bootstrap_and_start_mysql_router.assert_called_with(
-            "test_user", "s3kr1t", "testapp", "10.10.0.1", "3306", True
+            "test_user", "s3kr1t", "testapp", "10.10.0.1", "3306", force=True
         )

--- a/tests/unit/test_mysql_router_helpers.py
+++ b/tests/unit/test_mysql_router_helpers.py
@@ -7,10 +7,11 @@ from unittest.mock import call, patch
 
 from charms.operator_libs_linux.v1.systemd import SystemdError
 
-from constants import MYSQL_ROUTER_SERVICE_NAME, ROOT_GROUP, ROOT_USER
+from constants import MYSQL_ROUTER_SERVICE_NAME
 from mysql_router_helpers import MySQLRouter, MySQLRouterBootstrapError
 
 bootstrap_cmd = [
+    "sudo",
     "/usr/bin/mysqlrouter",
     "--user",
     "mysql",
@@ -32,6 +33,7 @@ bootstrap_cmd = [
     "--conf-use-gr-notifications",
 ]
 chmod_cmd = [
+    "sudo",
     "chmod",
     "755",
     "/var/lib/mysql/testapp",
@@ -51,8 +53,8 @@ class TestMysqlRouterHelpers(unittest.TestCase):
             sorted(run.mock_calls),
             sorted(
                 [
-                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
-                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(bootstrap_cmd),
+                    call(chmod_cmd),
                 ]
             ),
         )
@@ -72,8 +74,8 @@ class TestMysqlRouterHelpers(unittest.TestCase):
             sorted(run.mock_calls),
             sorted(
                 [
-                    call(bootstrap_cmd + ["--force"], user=ROOT_USER, group=ROOT_GROUP),
-                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(bootstrap_cmd + ["--force"]),
+                    call(chmod_cmd),
                 ]
             ),
         )
@@ -95,7 +97,7 @@ class TestMysqlRouterHelpers(unittest.TestCase):
                 "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
             )
 
-        run.assert_called_with(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP)
+        run.assert_called_with(bootstrap_cmd)
         render_and_copy.assert_not_called()
         systemd.daemon_reload.assert_not_called()
         systemd.service_start.assert_not_called()
@@ -120,8 +122,8 @@ class TestMysqlRouterHelpers(unittest.TestCase):
             sorted(run.mock_calls),
             sorted(
                 [
-                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
-                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(bootstrap_cmd),
+                    call(chmod_cmd),
                 ]
             ),
         )
@@ -148,8 +150,8 @@ class TestMysqlRouterHelpers(unittest.TestCase):
             sorted(run.mock_calls),
             sorted(
                 [
-                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
-                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(bootstrap_cmd),
+                    call(chmod_cmd),
                 ]
             ),
         )
@@ -176,8 +178,8 @@ class TestMysqlRouterHelpers(unittest.TestCase):
             sorted(run.mock_calls),
             sorted(
                 [
-                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
-                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(bootstrap_cmd),
+                    call(chmod_cmd),
                 ]
             ),
         )

--- a/tests/unit/test_mysql_router_helpers.py
+++ b/tests/unit/test_mysql_router_helpers.py
@@ -2,16 +2,15 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from subprocess import STDOUT, CalledProcessError
-from unittest.mock import patch
+from subprocess import CalledProcessError
+from unittest.mock import call, patch
 
 from charms.operator_libs_linux.v1.systemd import SystemdError
 
-from constants import MYSQL_ROUTER_SERVICE_NAME
+from constants import MYSQL_ROUTER_SERVICE_NAME, ROOT_GROUP, ROOT_USER
 from mysql_router_helpers import MySQLRouter, MySQLRouterBootstrapError
 
 bootstrap_cmd = [
-    "sudo",
     "/usr/bin/mysqlrouter",
     "--user",
     "mysql",
@@ -32,29 +31,52 @@ bootstrap_cmd = [
     "http_server.bind_address=127.0.0.1",
     "--conf-use-gr-notifications",
 ]
+chmod_cmd = [
+    "chmod",
+    "755",
+    "/var/lib/mysql/testapp",
+]
 
 
 class TestMysqlRouterHelpers(unittest.TestCase):
     @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
     @patch("mysql_router_helpers.systemd")
-    @patch("mysql_router_helpers.subprocess.check_output")
-    def test_bootstrap_and_start_mysql_router(self, check_output, systemd, render_and_copy):
+    @patch("mysql_router_helpers.subprocess.run")
+    def test_bootstrap_and_start_mysql_router(self, run, systemd, render_and_copy):
         MySQLRouter.bootstrap_and_start_mysql_router(
             "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
         )
-        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+
+        self.assertEqual(
+            sorted(run.mock_calls),
+            sorted(
+                [
+                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                ]
+            ),
+        )
         render_and_copy.assert_called_with("testapp")
         systemd.daemon_reload.assert_called_with()
         systemd.service_start.assert_called_with(MYSQL_ROUTER_SERVICE_NAME)
 
     @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
     @patch("mysql_router_helpers.systemd")
-    @patch("mysql_router_helpers.subprocess.check_output")
-    def test_bootstrap_and_start_mysql_router_force(self, check_output, systemd, render_and_copy):
+    @patch("mysql_router_helpers.subprocess.run")
+    def test_bootstrap_and_start_mysql_router_force(self, run, systemd, render_and_copy):
         MySQLRouter.bootstrap_and_start_mysql_router(
-            "test_user", "qweqwe", "testapp", "10.10.0.1", "3306", True
+            "test_user", "qweqwe", "testapp", "10.10.0.1", "3306", force=True
         )
-        check_output.assert_called_with(bootstrap_cmd + ["--force"], stderr=STDOUT)
+
+        self.assertEqual(
+            sorted(run.mock_calls),
+            sorted(
+                [
+                    call(bootstrap_cmd + ["--force"], user=ROOT_USER, group=ROOT_GROUP),
+                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                ]
+            ),
+        )
         render_and_copy.assert_called_with("testapp")
         systemd.daemon_reload.assert_called_with()
         systemd.service_start.assert_called_with(MYSQL_ROUTER_SERVICE_NAME)
@@ -62,29 +84,30 @@ class TestMysqlRouterHelpers(unittest.TestCase):
     @patch("mysql_router_helpers.logger")
     @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
     @patch("mysql_router_helpers.systemd")
-    @patch("mysql_router_helpers.subprocess.check_output")
+    @patch("mysql_router_helpers.subprocess.run")
     def test_bootstrap_and_start_mysql_router_subprocess_error(
-        self, check_output, systemd, render_and_copy, logger
+        self, run, systemd, render_and_copy, logger
     ):
         e = CalledProcessError(1, bootstrap_cmd)
-        check_output.side_effect = e
+        run.side_effect = e
         with self.assertRaises(MySQLRouterBootstrapError):
             MySQLRouter.bootstrap_and_start_mysql_router(
                 "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
             )
-        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+
+        run.assert_called_with(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP)
         render_and_copy.assert_not_called()
         systemd.daemon_reload.assert_not_called()
         systemd.service_start.assert_not_called()
-        logger.exception.assert_called_with("Failed to bootstrap mysqlrouter", exc_info=e)
+        logger.exception.assert_called_with("Failed to bootstrap mysqlrouter")
 
     @patch("mysql_router_helpers.logger")
     @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
     @patch("mysql_router_helpers.systemd.service_start")
     @patch("mysql_router_helpers.systemd.daemon_reload")
-    @patch("mysql_router_helpers.subprocess.check_output")
+    @patch("mysql_router_helpers.subprocess.run")
     def test_bootstrap_and_start_mysql_router_systemd_error(
-        self, check_output, daemon_reload, service_start, render_and_copy, logger
+        self, run, daemon_reload, service_start, render_and_copy, logger
     ):
         e = SystemdError()
         daemon_reload.side_effect = e
@@ -92,28 +115,44 @@ class TestMysqlRouterHelpers(unittest.TestCase):
             MySQLRouter.bootstrap_and_start_mysql_router(
                 "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
             )
-        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+
+        self.assertEqual(
+            sorted(run.mock_calls),
+            sorted(
+                [
+                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                ]
+            ),
+        )
         render_and_copy.assert_called_with("testapp")
         daemon_reload.assert_called_with()
         service_start.assert_not_called()
-        logger.exception.assert_called_with(
-            "Failed to set up mysqlrouter as a systemd service", exc_info=e
-        )
+        logger.exception.assert_called_with("Failed to set up mysqlrouter as a systemd service")
 
     @patch("mysql_router_helpers.logger")
     @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
     @patch("mysql_router_helpers.systemd.service_start")
     @patch("mysql_router_helpers.systemd.daemon_reload")
-    @patch("mysql_router_helpers.subprocess.check_output")
+    @patch("mysql_router_helpers.subprocess.run")
     def test_bootstrap_and_start_mysql_router_no_daemon_reload(
-        self, check_output, daemon_reload, service_start, render_and_copy, logger
+        self, run, daemon_reload, service_start, render_and_copy, logger
     ):
         daemon_reload.return_value = False
         with self.assertRaises(MySQLRouterBootstrapError):
             MySQLRouter.bootstrap_and_start_mysql_router(
                 "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
             )
-        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+
+        self.assertEqual(
+            sorted(run.mock_calls),
+            sorted(
+                [
+                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                ]
+            ),
+        )
         render_and_copy.assert_called_with("testapp")
         daemon_reload.assert_called_with()
         service_start.assert_not_called()
@@ -123,16 +162,25 @@ class TestMysqlRouterHelpers(unittest.TestCase):
     @patch("mysql_router_helpers.MySQLRouter._render_and_copy_mysqlrouter_systemd_unit_file")
     @patch("mysql_router_helpers.systemd.service_start")
     @patch("mysql_router_helpers.systemd.daemon_reload")
-    @patch("mysql_router_helpers.subprocess.check_output")
+    @patch("mysql_router_helpers.subprocess.run")
     def test_bootstrap_and_start_mysql_router_no_service_start(
-        self, check_output, daemon_reload, service_start, render_and_copy, logger
+        self, run, daemon_reload, service_start, render_and_copy, logger
     ):
         service_start.return_value = False
         with self.assertRaises(MySQLRouterBootstrapError):
             MySQLRouter.bootstrap_and_start_mysql_router(
                 "test_user", "qweqwe", "testapp", "10.10.0.1", "3306"
             )
-        check_output.assert_called_with(bootstrap_cmd, stderr=STDOUT)
+
+        self.assertEqual(
+            sorted(run.mock_calls),
+            sorted(
+                [
+                    call(bootstrap_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                    call(chmod_cmd, user=ROOT_USER, group=ROOT_GROUP),
+                ]
+            ),
+        )
         render_and_copy.assert_called_with("testapp")
         daemon_reload.assert_called_with()
         service_start.assert_called_with(MYSQL_ROUTER_SERVICE_NAME)


### PR DESCRIPTION
[dpe-1366](https://warthogs.atlassian.net/browse/DPE-1366), [issue 20](https://github.com/canonical/mysql-router-operator/issues/20)

## Issue
Even though the mysql socket file has 777 permissions, the socket's parent directory has 700 which results in restricted access to the socket file by other users.

```
ubuntu@juju-a99e94-5:~$ sudo ls -la /var/lib/mysql/slurmdbd/                                          
total 40
drwx------ 5 mysql mysql 4096 Mar 16 15:31 .
drwxr-xr-x 3 mysql mysql 4096 Mar 16 15:31 ..
drwx------ 2 mysql mysql 4096 Mar 16 15:31 data
drwx------ 2 mysql mysql 4096 Mar 16 15:31 log
srwxrwxrwx 1 mysql mysql    0 Mar 16 15:31 mysql.sock
srwxrwxrwx 1 mysql mysql    0 Mar 16 15:31 mysqlro.sock
-rw------- 1 mysql mysql 2358 Mar 16 15:31 mysqlrouter.conf
-rw------- 1 mysql mysql   94 Mar 16 15:31 mysqlrouter.key
-rw-r--r-- 1 mysql mysql    6 Mar 16 15:31 mysqlrouter.pid
srwxrwxrwx 1 mysql mysql    0 Mar 16 15:31 mysqlx.sock
srwxrwxrwx 1 mysql mysql    0 Mar 16 15:31 mysqlxro.sock
drwx------ 2 mysql mysql 4096 Mar 16 15:31 run
-rwx------ 1 mysql mysql  293 Mar 16 15:31 start.sh
-rwx------ 1 mysql mysql  179 Mar 16 15:31 stop.sh 
ubuntu@juju-a99e94-5:~$ ls -la /var/lib/mysql/slurmdbd/mysql.sock                                     
ls: cannot access '/var/lib/mysql/slurmdbd/mysql.sock': Permission denied
```

## Solution
Change permissions of the socket file's parent directory to 755

```
ubuntu@juju-a99e94-5:~$ ls -la /var/lib/mysql/slurmdbd/mysql.sock
ls: cannot access '/var/lib/mysql/slurmdbd/mysql.sock': Permission denied
ubuntu@juju-a99e94-5:~$ sudo chmod 755 /var/lib/mysql/slurmdbd/
ubuntu@juju-a99e94-5:~$ ls -la /var/lib/mysql/slurmdbd/mysql.sock
srwxrwxrwx 1 mysql mysql 0 Mar 16 15:31 /var/lib/mysql/slurmdbd/mysql.sock
```