### PR TITLE
Add missing permissions to build_charms_with_cache.yaml workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
     name: Build charms
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
     permissions:
-      actions: write  # Needed to manage GitHub cache
+      actions: write  # Needed to manage GitHub Actions cache
 
   integration-test:
     strategy:


### PR DESCRIPTION
Ported from https://github.com/canonical/mysql-router-k8s-operator/pull/108
