### PR TITLE
Enable codecov informational mode

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,5 +3,8 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true
 github_checks:
   annotations: false


### PR DESCRIPTION
CI should not fail if code coverage drops

Except for TLS and the legacy shared-db relation (which I skipped in #54), adding additional unit testing would have, imo, little to negative value since it would require extensive mocking and would essentially only be testing if the internal APIs of the charm have changed (which they should, as the charm evolves and is refactored)

Therefore, I don't think it's useful to have a failed CI run if code coverage drops
