### PR TITLE
Fix scenario unit test call

### DIFF
--- a/tests/unit/scenario_/database_relations/combinations.py
+++ b/tests/unit/scenario_/database_relations/combinations.py
@@ -19,7 +19,7 @@ def _relation_combinations(
             combination: tuple[scenario.SubordinateRelation]
             combinations.append(
                 [
-                    relation.replace(relation_id=scenario.SubordinateRelation.next_relation_id())
+                    relation.replace(relation_id=scenario.state.next_relation_id())
                     for relation in combination
                 ]
             )


### PR DESCRIPTION
ops-scenario 4.0.3 introduced a breaking change

Since we're not yet pinning dependencies, the CI passed on #56 but failed on release (since ops-scenario updated)
