### PR TITLE
Remove bootstrapping after TLS enabled/disabled

### DIFF
--- a/src/workload.py
+++ b/src/workload.py
@@ -217,7 +217,6 @@ class AuthenticatedWorkload(Workload):
         """Restart MySQL Router to enable or disable TLS."""
         logger.debug("Restarting MySQL Router")
         assert self._container.mysql_router_service_enabled is True
-        self._bootstrap_router(tls=tls)
         self._container.update_mysql_router_service(enabled=True, tls=tls)
         logger.debug("Restarted MySQL Router")
         self._charm.wait_until_mysql_router_ready()

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,8 @@ deps =
     pytest-xdist
     ; `pytest-cov` used instead of `coverage` for `pytest-xdist` support
     pytest-cov
+    # Workaround for https://github.com/canonical/ops-scenario/issues/48
+    ops<2.5
     ops-scenario
     -r {tox_root}/requirements.txt
 commands =


### PR DESCRIPTION
Ported from https://github.com/canonical/mysql-router-k8s-operator/pull/117

Leftover from #44
