### PR TITLE
Fix bug in lifecycle.py for subordinate charms without other relations

### DIFF
--- a/src/lifecycle.py
+++ b/src/lifecycle.py
@@ -123,6 +123,9 @@ class Unit(ops.Object):
         if "dying" in principal_unit_statuses and principal_unit_statuses != {"dying"}:
             # Situation #4
             self._unit_tearing_down_and_app_active = _UnitTearingDownAndAppActive.TRUE
+        else:
+            # Situation #1, #2, or #3
+            self._unit_tearing_down_and_app_active = _UnitTearingDownAndAppActive.FALSE
 
     @property
     def authorized_leader(self) -> bool:


### PR DESCRIPTION
_UnitTearingDownAndAppActive was set to UNKNOWN for subordinate charms without non-subordinate relations during relation-broken
