### PR TITLE
Remove build-wrapper from integration tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,12 +83,7 @@ pass_env =
     CI
     GITHUB_OUTPUT
     SECRETS_FROM_GITHUB
-allowlist_externals =
-    {[testenv:pack-wrapper]allowlist_externals}
 commands_pre =
     poetry install --only integration
-    {[testenv:pack-wrapper]commands_pre}
 commands =
     poetry run pytest -v --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}
-commands_post =
-    {[testenv:pack-wrapper]commands_post}


### PR DESCRIPTION
Ported from https://github.com/canonical/mysql-router-k8s-operator/pull/216
