### PR TITLE
Check if highest unit has upgraded before resuming upgrade

### DIFF
--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -115,6 +115,23 @@ class Upgrade(upgrade.Upgrade):
     def reconcile_partition(self, *, action_event: ops.ActionEvent = None) -> None:
         """Handle Juju action to confirm first upgraded unit is healthy and resume upgrade."""
         if action_event:
+            unit = self._sorted_units[0]  # First unit to upgrade
+            state = self._peer_relation.data[unit].get("state")
+            if state:
+                state = upgrade.UnitState(state)
+            outdated = (
+                self._unit_workload_container_versions.get(unit.name)
+                != self._app_workload_container_version
+            )
+            unhealthy = state is not upgrade.UnitState.HEALTHY
+            if outdated or unhealthy:
+                if outdated:
+                    message = "Highest number unit has not upgraded yet. Upgrade will not resume."
+                else:
+                    message = "Highest number unit is unhealthy. Upgrade will not resume."
+                logger.debug(f"Resume upgrade event failed: {message}")
+                action_event.fail(message)
+                return
             self.upgrade_resumed = True
             message = "Upgrade resumed."
             action_event.set_results({"result": message})


### PR DESCRIPTION
Matches existing Kubernetes implementation
https://github.com/canonical/mysql-router-k8s-operator/blob/7aba973ba4c859e7de1ef84b1b1f6a203f796941/src/kubernetes_upgrade.py#L219-L223