### PR TITLE
Don't return upgrade app status if upgrade not in progress

### DIFF
--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -71,6 +71,8 @@ class Upgrade(upgrade.Upgrade):
 
     @property
     def app_status(self) -> typing.Optional[ops.StatusBase]:
+        if not self.in_progress:
+            return
         if not self.is_compatible:
             logger.info(
                 "Upgrade incompatible. If you accept potential *data loss* and *downtime*, you can continue by running `force-upgrade` action on each remaining unit"


### PR DESCRIPTION
Fixes potential race condition on opensearch charm where upgrade status checked during initial startup
