### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,9 @@ jobs:
       # Use of cache blocked by https://github.com/canonical/charmcraft/issues/1456
       # Details: https://github.com/canonical/charmcraftcache/issues/3
       cache: false
+      # Remove prefix when cache enabled
+      # Needed to avoid conflict with artifact name on release CI
+      artifact-prefix: ci-packed-charm-cache-false-.
 
   gh-hosted-collect-integration-tests:
     name: (GH hosted) Collect integration test groups


### PR DESCRIPTION
Since ci.yaml build doesn't use cache, the artifact name conflicts with release.yaml build

Follow up to #152
