### PR TITLE
Update sync_docs.yaml

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -1,33 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
 name: Sync docs from Discourse
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: '53 0 * * *' # Daily at 00:53 UTC
-  push:
-    branches:
-      - main
+    - cron: 40 00 * * *
 
 jobs:
   sync-docs:
-    name: Open PR with docs changes
-    runs-on: ubuntu-latest
+    name: Sync docs from Discourse
+    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@main
+    secrets:
+      discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
+      discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}
     permissions:
-      contents: write  # Needed to login to Discourse
-      pull-requests: write # Need to create PR
-    steps:
-      - uses: actions/checkout@v3
-      - name: Open PR with docs changes
-        uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
-        id: docs-pr
-        with:
-          discourse_host: discourse.charmhub.io
-          discourse_api_username: ${{ secrets.DISCOURSE_API_USERNAME }}
-          discourse_api_key: ${{ secrets.DISCOURSE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: "true"
-
-      - name: Show migrate output
-        run: echo '${{ steps.docs-pr.outputs.migrate }}'
-      - name: Show reconcile output
-        run: echo '${{ steps.docs-pr.outputs.reconcile }}'
+      contents: write  # Needed to push branch & tag
+      pull-requests: write  # Needed to create PR


### PR DESCRIPTION
## Issue
Current documentation sync workflow calls old discourse-gatekeeper fork. 

## Solution
Updated to use the new [`sync_docs.yaml` shared workflow](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/_sync_docs.md), which calls the latest version of the action.