### PR TITLE
Update router exporter listen ports to custom reserved port

### DIFF
--- a/src/relations/cos.py
+++ b/src/relations/cos.py
@@ -28,12 +28,13 @@ class ExporterConfig:
     url: str
     username: str
     password: str
+    listen_port: str
 
 
 class COSRelation:
     """Relation with the cos bundle."""
 
-    _EXPORTER_PORT = "49152"
+    _EXPORTER_PORT = "9152"
     HTTP_SERVER_PORT = "8443"
     _NAME = "cos-agent"
     _PEER_RELATION_NAME = "cos"
@@ -77,6 +78,7 @@ class COSRelation:
             url=f"https://127.0.0.1:{self.HTTP_SERVER_PORT}",
             username=self.MONITORING_USERNAME,
             password=self.get_monitoring_password(),
+            listen_port=self._EXPORTER_PORT,
         )
 
     @property

--- a/src/snap.py
+++ b/src/snap.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _SNAP_NAME = "charmed-mysql"
 REVISIONS: typing.Dict[str, str] = {
     # Keep in sync with `workload_version` file
-    "x86_64": "106",
+    "x86_64": "108",
     "aarch64": "107",
 }
 revision = REVISIONS[platform.machine()]
@@ -220,6 +220,7 @@ class Snap(container.Container):
         if enabled:
             _snap.set(
                 {
+                    "mysqlrouter-exporter.listen-port": config.listen_port,
                     "mysqlrouter-exporter.user": config.username,
                     "mysqlrouter-exporter.password": config.password,
                     "mysqlrouter-exporter.url": config.url,
@@ -241,6 +242,7 @@ class Snap(container.Container):
             _snap.start([self._EXPORTER_SERVICE_NAME], enable=True)
         else:
             _snap.stop([self._EXPORTER_SERVICE_NAME], disable=True)
+            _snap.unset("mysqlrouter-exporter.listen-port")
             _snap.unset("mysqlrouter-exporter.user")
             _snap.unset("mysqlrouter-exporter.password")
             _snap.unset("mysqlrouter-exporter.url")

--- a/tests/integration/test_exporter.py
+++ b/tests/integration/test_exporter.py
@@ -129,7 +129,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, mysql_router_charm_series: s
     unit_address = await unit.get_public_address()
 
     try:
-        http.request("GET", f"http://{unit_address}:49152/metrics")
+        http.request("GET", f"http://{unit_address}:9152/metrics")
     except urllib3.exceptions.MaxRetryError as e:
         assert (
             "[Errno 111] Connection refused" in e.reason.args[0]
@@ -151,7 +151,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, mysql_router_charm_series: s
         wait=tenacity.wait_fixed(10),
     ):
         with attempt:
-            jmx_resp = http.request("GET", f"http://{unit_address}:49152/metrics")
+            jmx_resp = http.request("GET", f"http://{unit_address}:9152/metrics")
             assert (
                 jmx_resp.status == 200
             ), "❌ cannot connect to metrics endpoint with relation with cos"
@@ -171,7 +171,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, mysql_router_charm_series: s
     ):
         with attempt:
             try:
-                http.request("GET", f"http://{unit_address}:49152/metrics")
+                http.request("GET", f"http://{unit_address}:9152/metrics")
             except urllib3.exceptions.MaxRetryError as e:
                 assert (
                     "[Errno 111] Connection refused" in e.reason.args[0]
@@ -226,7 +226,7 @@ async def test_exporter_endpoint_with_tls(ops_test: OpsTest) -> None:
     ):
         with attempt:
             try:
-                http.request("GET", f"http://{unit_address}:49152/metrics")
+                http.request("GET", f"http://{unit_address}:9152/metrics")
             except urllib3.exceptions.MaxRetryError as e:
                 assert (
                     "[Errno 111] Connection refused" in e.reason.args[0]
@@ -248,7 +248,7 @@ async def test_exporter_endpoint_with_tls(ops_test: OpsTest) -> None:
         wait=tenacity.wait_fixed(10),
     ):
         with attempt:
-            jmx_resp = http.request("GET", f"http://{unit_address}:49152/metrics")
+            jmx_resp = http.request("GET", f"http://{unit_address}:9152/metrics")
             assert (
                 jmx_resp.status == 200
             ), "❌ cannot connect to metrics endpoint with relation with cos"
@@ -275,7 +275,7 @@ async def test_exporter_endpoint_with_tls(ops_test: OpsTest) -> None:
     ):
         with attempt:
             try:
-                http.request("GET", f"http://{unit_address}:49152/metrics")
+                http.request("GET", f"http://{unit_address}:9152/metrics")
             except urllib3.exceptions.MaxRetryError as e:
                 assert (
                     "[Errno 111] Connection refused" in e.reason.args[0]


### PR DESCRIPTION
## Issue
We are using port `49152` (default) for router exporter, which is an ephemeral port used by MySQLRouter when connecting to MySQL (causing `bind-address in use` issues when starting router exporter)

## Solution
Use custom port `9152` instead on x86 to confirm exporter test stabilization