### PR TITLE
Update 3.6 nightly tests to run against 3.6/candidate instead of 3.6/beta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,10 +116,10 @@ jobs:
             bases-index: 0
           - series: jammy
             bases-index: 1
-        juju-snap-channel:  ["2.9/stable", "3.4/stable", "3.6/beta"]
+        juju-snap-channel:  ["2.9/stable", "3.4/stable", "3.6/candidate"]
         include:
-          - juju-snap-channel: "3.6/beta"
-            agent-version: "3.6-beta2"
+          - juju-snap-channel: "3.6/candidate"
+            agent-version: "3.6-rc2"
             libjuju-version: "3.5.2.0"
           - juju-snap-channel: "3.4/stable"
             agent-version: "3.4.3"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
             agent-version: "3.4.3"
             libjuju-version:  "3.5.2.0"
           - juju-snap-channel: "2.9/stable"
-            agent-version: "2.9.45"
+            agent-version: "2.9.51"
             libjuju-version:  "2.9.49.0"
         exclude:
           - groups: {path_to_test_file: tests/integration/test_data_integrator.py}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
             libjuju-version:  "3.5.2.0"
           - juju-snap-channel: "2.9/stable"
             agent-version: "2.9.45"
-            libjuju-version:  "2.9.44.1"
+            libjuju-version:  "2.9.49.0"
         exclude:
           - groups: {path_to_test_file: tests/integration/test_data_integrator.py}
             ubuntu-versions: {series: focal}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,7 @@ jobs:
           bootstrap-options: "--agent-version ${{ matrix.agent-version }}"
           juju-channel: ${{ matrix.juju-snap-channel }}
       - name: Update python-libjuju version
-        if: ${{ matrix.libjuju-version == '2.9.44.1' }}
+        if: ${{ matrix.libjuju-version == '2.9.49.0' }}
         run: poetry add --lock --group integration juju@'${{ matrix.libjuju-version }}'
       - name: Download packed charm(s)
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Issue
We are not running tests on juju 3.6/*

## Solution
Run tests against juju 3.6/candidate on a nightly schedule