### PR TITLE
[DPE-5711] Add warnings to destructive actions

### DIFF
--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -197,14 +197,15 @@ class MachineSubordinateRouterCharm(abstract_charm.MySQLRouterCharm):
             logger.debug(f"Force upgrade event failed: {message}")
             event.fail(message)
             return
-        logger.debug("Forcing upgrade")
+
+        logger.warning("Forcing upgrade")
         event.log(f"Forcefully upgrading {self.unit.name}")
         self._upgrade.upgrade_unit(
             event=event, workload_=self.get_workload(event=None), tls=self._tls_certificate_saved
         )
         self.reconcile()
         event.set_results({"result": f"Forcefully upgraded {self.unit.name}"})
-        logger.debug("Forced upgrade")
+        logger.warning("Forced upgrade")
 
 
 if __name__ == "__main__":

--- a/src/workload.py
+++ b/src/workload.py
@@ -145,14 +145,14 @@ class Workload:
 
     def _disable_router(self) -> None:
         """Disable router and clean up corresponding router files."""
-        logger.debug("Disabling MySQL Router service")
+        logger.info("Disabling MySQL Router service")
         self._container.update_mysql_router_service(enabled=False)
         self._logrotate.disable()
         self._container.router_config_directory.rmtree()
         self._container.router_config_directory.mkdir()
         self._router_data_directory.rmtree()
         self._router_data_directory.mkdir()
-        logger.debug("Disabled MySQL Router service")
+        logger.info("Disabled MySQL Router service")
 
     def reconcile(
         self,


### PR DESCRIPTION
This PR adds warning level messages when a _destructive_ action is performed. The definition of _destructive_ seems to be associated with data loss, which I think it can only happen, from user action, whenever they force an upgrade when the charm has already detected its lack of compatibility.

### Additional info
- Paulo confirmed that this ticket was created to familiarised myself with the codebases.
- Alex referenced this PostgreSQL operator [PR](https://github.com/canonical/postgresql-k8s-operator/pull/753) as the reason behind the need for warnings.