### PR TITLE
Run juju 3.6 nightly tests against 3.6/stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,10 +116,10 @@ jobs:
             bases-index: 0
           - series: jammy
             bases-index: 1
-        juju-snap-channel:  ["2.9/stable", "3.4/stable", "3.6/candidate"]
+        juju-snap-channel:  ["2.9/stable", "3.4/stable", "3.6/stable"]
         include:
-          - juju-snap-channel: "3.6/candidate"
-            agent-version: "3.6-rc2"
+          - juju-snap-channel: "3.6/stable"
+            agent-version: "3.6.0"
             libjuju-version: "3.5.2.0"
           - juju-snap-channel: "3.4/stable"
             agent-version: "3.4.3"


### PR DESCRIPTION
## Issue
Juju 3.6/stable was released

## Solution
Run juju 3.6 nightly tests against 3.6/stable