### PR TITLE
[DPE-5588] Check against invalid arch

### DIFF
--- a/src/architecture.py
+++ b/src/architecture.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Architecture utilities module"""
+
+import logging
+import os
+import pathlib
+import platform
+
+import yaml
+from ops.charm import CharmBase
+from ops.model import BlockedStatus
+
+logger = logging.getLogger(__name__)
+
+
+class WrongArchitectureWarningCharm(CharmBase):
+    """A fake charm class that only signals a wrong architecture deploy."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        hw_arch = platform.machine()
+        self.unit.status = BlockedStatus(
+            f"Charm incompatible with {hw_arch} architecture. "
+            f"If this app is being refreshed, rollback"
+        )
+        raise RuntimeError(
+            f"Incompatible architecture: this charm revision does not support {hw_arch}. "
+            f"If this app is being refreshed, rollback with instructions from Charmhub docs. "
+            f"If this app is being deployed for the first time, remove it and deploy it again "
+            f"using a compatible revision."
+        )
+
+
+def is_wrong_architecture() -> bool:
+    """Checks if charm was deployed on wrong architecture."""
+    charm_path = os.environ.get("CHARM_DIR", "")
+    manifest_path = pathlib.Path(charm_path, "manifest.yaml")
+
+    if not manifest_path.exists():
+        logger.error("Cannot check architecture: manifest file not found in %s", manifest_path)
+        return False
+
+    manifest = yaml.safe_load(manifest_path.read_text())
+
+    manifest_archs = []
+    for base in manifest["bases"]:
+        base_archs = base.get("architectures", [])
+        manifest_archs.extend(base_archs)
+
+    hardware_arch = platform.machine()
+    if ("amd64" in manifest_archs and hardware_arch == "x86_64") or (
+        "arm64" in manifest_archs and hardware_arch == "aarch64"
+    ):
+        logger.debug("Charm architecture matches")
+        return False
+
+    logger.error("Charm architecture does not match")
+    return True

--- a/src/machine_charm.py
+++ b/src/machine_charm.py
@@ -6,11 +6,17 @@
 
 """MySQL Router machine charm"""
 
+import ops
+
+from architecture import WrongArchitectureWarningCharm, is_wrong_architecture
+
+if is_wrong_architecture() and __name__ == "__main__":
+    ops.main.main(WrongArchitectureWarningCharm)
+
 import logging
 import socket
 import typing
 
-import ops
 import tenacity
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import argparse
+import subprocess
 
 import pytest
 
@@ -30,6 +31,30 @@ def pytest_configure(config):
         config.option.mysql_router_charm_series = "jammy"
     if config.option.mysql_router_charm_bases_index is None:
         config.option.mysql_router_charm_bases_index = 1
+
+
+@pytest.fixture(autouse=True)
+def architecture() -> str:
+    return subprocess.run(
+        ["dpkg", "--print-architecture"],
+        capture_output=True,
+        check=True,
+        encoding="utf-8",
+    ).stdout.strip()
+
+
+@pytest.fixture
+def only_amd64(architecture):
+    """Pretty way to skip ARM tests."""
+    if architecture != "amd64":
+        pytest.skip("Requires amd64 architecture")
+
+
+@pytest.fixture
+def only_arm64(architecture):
+    """Pretty way to skip AMD tests."""
+    if architecture != "arm64":
+        pytest.skip("Requires arm64 architecture")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,13 @@ def only_arm64(architecture):
 
 
 @pytest.fixture
+def only_ubuntu_jammy(mysql_router_charm_series):
+    """Pretty way to skip < Ubuntu 22.04 tests."""
+    if mysql_router_charm_series != "jammy":
+        pytest.skip("Requires Ubuntu Jammy")
+
+
+@pytest.fixture
 def only_with_juju_secrets(juju_has_secrets):
     """Pretty way to skip Juju 3 tests."""
     if not juju_has_secrets:

--- a/tests/integration/test_architecture.py
+++ b/tests/integration/test_architecture.py
@@ -20,7 +20,6 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
         charm,
         application_name=MYSQL_ROUTER_APP_NAME,
         num_units=1,
-        config={"profile": "testing"},
         base="ubuntu@22.04",
     )
 
@@ -41,7 +40,6 @@ async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
         charm,
         application_name=MYSQL_ROUTER_APP_NAME,
         num_units=1,
-        config={"profile": "testing"},
         base="ubuntu@22.04",
     )
 

--- a/tests/integration/test_architecture.py
+++ b/tests/integration/test_architecture.py
@@ -14,7 +14,7 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 
 @pytest.mark.group(1)
-@pytest.mark.usefixtures("only_amd64")
+@pytest.mark.usefixtures("only_amd64", "only_ubuntu_jammy")
 async def test_arm_charm_on_amd_host(ops_test: OpsTest, mysql_router_charm_series: str) -> None:
     """Tries deploying an arm64 charm on amd64 host."""
     charm = await get_charm(".", "arm64", 2)
@@ -48,7 +48,7 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest, mysql_router_charm_serie
 
 
 @pytest.mark.group(1)
-@pytest.mark.usefixtures("only_arm64")
+@pytest.mark.usefixtures("only_arm64", "only_ubuntu_jammy")
 async def test_amd_charm_on_arm_host(ops_test: OpsTest, mysql_router_charm_series: str) -> None:
     """Tries deploying an amd64 charm on arm64 host."""
     charm = await get_charm(".", "amd64", 1)

--- a/tests/integration/test_architecture.py
+++ b/tests/integration/test_architecture.py
@@ -19,7 +19,7 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(
         charm,
         application_name=MYSQL_ROUTER_APP_NAME,
-        num_units=1,
+        num_units=0,
         base="ubuntu@22.04",
     )
 
@@ -39,7 +39,7 @@ async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(
         charm,
         application_name=MYSQL_ROUTER_APP_NAME,
-        num_units=1,
+        num_units=0,
         base="ubuntu@22.04",
     )
 

--- a/tests/integration/test_architecture.py
+++ b/tests/integration/test_architecture.py
@@ -2,25 +2,42 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
+
 import pytest
 from pytest_operator.plugin import OpsTest
 
 from .helpers import get_charm
 
 MYSQL_ROUTER_APP_NAME = "mysql-router"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 
 @pytest.mark.group(1)
 @pytest.mark.usefixtures("only_amd64")
-async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
+async def test_arm_charm_on_amd_host(ops_test: OpsTest, mysql_router_charm_series: str) -> None:
     """Tries deploying an arm64 charm on amd64 host."""
     charm = await get_charm(".", "arm64", 2)
 
-    await ops_test.model.deploy(
-        charm,
-        application_name=MYSQL_ROUTER_APP_NAME,
-        num_units=0,
-        base="ubuntu@22.04",
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=MYSQL_ROUTER_APP_NAME,
+            num_units=0,
+            series=mysql_router_charm_series,
+        ),
+        ops_test.model.deploy(
+            MYSQL_TEST_APP_NAME,
+            application_name=MYSQL_TEST_APP_NAME,
+            num_units=1,
+            channel="latest/edge",
+            series=mysql_router_charm_series,
+        ),
+    )
+
+    await ops_test.model.relate(
+        f"{MYSQL_ROUTER_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
     )
 
     await ops_test.model.wait_for_idle(
@@ -32,15 +49,29 @@ async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
 
 @pytest.mark.group(1)
 @pytest.mark.usefixtures("only_arm64")
-async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
+async def test_amd_charm_on_arm_host(ops_test: OpsTest, mysql_router_charm_series: str) -> None:
     """Tries deploying an amd64 charm on arm64 host."""
     charm = await get_charm(".", "amd64", 1)
 
-    await ops_test.model.deploy(
-        charm,
-        application_name=MYSQL_ROUTER_APP_NAME,
-        num_units=0,
-        base="ubuntu@22.04",
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=MYSQL_ROUTER_APP_NAME,
+            num_units=0,
+            series=mysql_router_charm_series,
+        ),
+        ops_test.model.deploy(
+            MYSQL_TEST_APP_NAME,
+            application_name=MYSQL_TEST_APP_NAME,
+            num_units=1,
+            channel="latest/edge",
+            series=mysql_router_charm_series,
+        ),
+    )
+
+    await ops_test.model.relate(
+        f"{MYSQL_ROUTER_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
     )
 
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_architecture.py
+++ b/tests/integration/test_architecture.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from .helpers import get_charm
+
+MYSQL_ROUTER_APP_NAME = "mysql-router"
+
+
+@pytest.mark.group(1)
+@pytest.mark.usefixtures("only_amd64")
+async def test_arm_charm_on_amd_host(ops_test: OpsTest) -> None:
+    """Tries deploying an arm64 charm on amd64 host."""
+    charm = await get_charm(".", "arm64", 2)
+
+    await ops_test.model.deploy(
+        charm,
+        application_name=MYSQL_ROUTER_APP_NAME,
+        num_units=1,
+        config={"profile": "testing"},
+        base="ubuntu@22.04",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MYSQL_ROUTER_APP_NAME],
+        status="error",
+        raise_on_error=False,
+    )
+
+
+@pytest.mark.group(1)
+@pytest.mark.usefixtures("only_arm64")
+async def test_amd_charm_on_arm_host(ops_test: OpsTest) -> None:
+    """Tries deploying an amd64 charm on arm64 host."""
+    charm = await get_charm(".", "amd64", 1)
+
+    await ops_test.model.deploy(
+        charm,
+        application_name=MYSQL_ROUTER_APP_NAME,
+        num_units=1,
+        config={"profile": "testing"},
+        base="ubuntu@22.04",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[MYSQL_ROUTER_APP_NAME],
+        status="error",
+        raise_on_error=False,
+    )

--- a/tests/unit/test_architecture.py
+++ b/tests/unit/test_architecture.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from unittest.mock import patch
+
+from architecture import is_wrong_architecture
+
+TEST_MANIFEST = """
+    bases:
+        - architectures:
+            - {arch}
+          channel: '22.04'
+          name: ubuntu
+"""
+
+
+def test_wrong_architecture_file_not_found():
+    """Tests if the function returns False when the charm file doesn't exist."""
+    with (
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=False),
+    ):
+        assert not is_wrong_architecture()
+
+
+def test_wrong_architecture_amd64():
+    """Tests if the function correctly identifies arch when charm is AMD."""
+    with (
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="amd64")),
+        patch("platform.machine") as machine,
+    ):
+        machine.return_value = "x86_64"
+        assert not is_wrong_architecture()
+        machine.return_value = "aarch64"
+        assert is_wrong_architecture()
+
+
+def test_wrong_architecture_arm64():
+    """Tests if the function correctly identifies arch when charm is ARM."""
+    with (
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="arm64")),
+        patch("platform.machine") as machine,
+    ):
+        machine.return_value = "x86_64"
+        assert is_wrong_architecture()
+        machine.return_value = "aarch64"
+        assert not is_wrong_architecture()

--- a/tests/unit/test_architecture.py
+++ b/tests/unit/test_architecture.py
@@ -2,8 +2,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import patch
-
 from architecture import is_wrong_architecture
 
 TEST_MANIFEST = """
@@ -15,38 +13,36 @@ TEST_MANIFEST = """
 """
 
 
-def test_wrong_architecture_file_not_found():
+def test_wrong_architecture_file_not_found(monkeypatch):
     """Tests if the function returns False when the charm file doesn't exist."""
-    with (
-        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
-        patch("pathlib.Path.exists", return_value=False),
-    ):
-        assert not is_wrong_architecture()
+    monkeypatch.setattr("os.environ", {"CHARM_DIR": "/tmp"})
+    monkeypatch.setattr("pathlib.Path.exists", lambda *args, **kwargs: False)
+    assert not is_wrong_architecture()
 
 
-def test_wrong_architecture_amd64():
+def test_wrong_architecture_amd64(monkeypatch):
     """Tests if the function correctly identifies arch when charm is AMD."""
-    with (
-        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
-        patch("pathlib.Path.exists", return_value=True),
-        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="amd64")),
-        patch("platform.machine") as machine,
-    ):
-        machine.return_value = "x86_64"
-        assert not is_wrong_architecture()
-        machine.return_value = "aarch64"
-        assert is_wrong_architecture()
+    manifest = TEST_MANIFEST.format(arch="amd64")
+    monkeypatch.setattr("os.environ", {"CHARM_DIR": "/tmp"})
+    monkeypatch.setattr("pathlib.Path.exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr("pathlib.Path.read_text", lambda *args, **kwargs: manifest)
+
+    monkeypatch.setattr("platform.machine", lambda *args, **kwargs: "x86_64")
+    assert not is_wrong_architecture()
+
+    monkeypatch.setattr("platform.machine", lambda *args, **kwargs: "aarch64")
+    assert is_wrong_architecture()
 
 
-def test_wrong_architecture_arm64():
+def test_wrong_architecture_arm64(monkeypatch):
     """Tests if the function correctly identifies arch when charm is ARM."""
-    with (
-        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
-        patch("pathlib.Path.exists", return_value=True),
-        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="arm64")),
-        patch("platform.machine") as machine,
-    ):
-        machine.return_value = "x86_64"
-        assert is_wrong_architecture()
-        machine.return_value = "aarch64"
-        assert not is_wrong_architecture()
+    manifest = TEST_MANIFEST.format(arch="arm64")
+    monkeypatch.setattr("os.environ", {"CHARM_DIR": "/tmp"})
+    monkeypatch.setattr("pathlib.Path.exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr("pathlib.Path.read_text", lambda *args, **kwargs: manifest)
+
+    monkeypatch.setattr("platform.machine", lambda *args, **kwargs: "x86_64")
+    assert is_wrong_architecture()
+
+    monkeypatch.setattr("platform.machine", lambda *args, **kwargs: "aarch64")
+    assert not is_wrong_architecture()


### PR DESCRIPTION
This PR introduces the usage of the newly created architecture module, similar to the one in the MySQL lib (see [code](https://github.com/canonical/mysql-operator/blob/main/lib/charms/mysql/v0/architecture.py)).

The shape of the integration tests, as well as the helper used to get the built charm in the architecture that mismatches the one of the host itself, have been adapted from the one Lucas created for PostgreSQL-k8s (see [code](https://github.com/canonical/postgresql-k8s-operator/blob/70a96ce33eb0de054b9297e3bd558f6ece54c0b0/tests/integration/test_wrong_arch.py)).

### Additional info

- The new logic has been added as a module, and not as a charm lib, due to @carlcsaposs-canonical preference.
- The integration test fixtures have been defined in `conftest.py` and not in `markers.py` to respect the existing setup.
- The integration test _base_ indexes have been tweaked, to account for [this legacy base](https://github.com/canonical/mysql-router-operator/blob/d0af04794698df4ae2a5166f30607ebb1d7cd975/charmcraft.yaml#L9-L11). Should we remove it?