### PR TITLE
[DPE-6447] Avoid storing passwords on disk when running mysqlsh

### DIFF
--- a/src/container.py
+++ b/src/container.py
@@ -196,14 +196,20 @@ class Container(abc.ABC):
         return self._run_command(args, timeout=timeout)
 
     # TODO python3.10 min version: Use `list` instead of `typing.List`
-    def run_mysql_shell(self, args: typing.List[str], *, timeout: int = None) -> str:
+    def run_mysql_shell(
+        self,
+        args: typing.List[str],
+        *,
+        timeout: int = None,
+        input: str = None,  # noqa: A002 Match subprocess.run()
+    ) -> str:
         """Run MySQL Shell command.
 
         Raises:
             CalledProcessError: Command returns non-zero exit code
         """
         args.insert(0, self._mysql_shell_command)
-        return self._run_command(args, timeout=timeout)
+        return self._run_command(args, timeout=timeout, input=input)
 
     @abc.abstractmethod
     def path(self, *args) -> Path:

--- a/src/mysql_shell/__init__.py
+++ b/src/mysql_shell/__init__.py
@@ -64,40 +64,29 @@ class Shell:
         template = _jinja_env.get_template("try_except_wrapper.py.jinja")
         error_file = self._container.path("/tmp/mysqlsh_error.json")
 
-        def render(connection_info: "relations.database_requires.ConnectionInformation"):
-            return template.render(
-                username=connection_info.username,
-                password=connection_info.password,
-                host=connection_info.host,
-                port=connection_info.port,
-                code=code,
-                error_filepath=error_file.relative_to_container,
-            )
+        script = template.render(code=code, error_filepath=error_file.relative_to_container)
 
-        # Redact password from log
-        logged_script = render(self._connection_info.redacted)
-
-        script = render(self._connection_info)
-        temporary_script_file = self._container.path("/tmp/mysqlsh_script.py")
-        error_file = self._container.path("/tmp/mysqlsh_error.json")
-        temporary_script_file.write_text(script)
         try:
-            self._container.run_mysql_shell([
-                "--no-wizard",
-                "--python",
-                "--file",
-                str(temporary_script_file.relative_to_container),
-            ])
+            self._container.run_mysql_shell(
+                [
+                    "--passwords-from-stdin",
+                    f"--uri={self._connection_info.username}@{self._connection_info.host}:{self._connection_info.port}",
+                    "--python",
+                    "-c",
+                    script,
+                ],
+                input=self._connection_info.password,
+            )
         except container.CalledProcessError as e:
             logger.exception(
-                f"Failed to run MySQL Shell script:\n{logged_script}\n\nstderr:\n{e.stderr}\n"
+                f"Failed to run MySQL Shell script:\n{script}\n\nstderr:\n{e.stderr}\n"
             )
             raise
-        finally:
-            temporary_script_file.unlink()
+
         with error_file.open("r") as file:
             exception = json.load(file)
         error_file.unlink()
+
         try:
             if exception:
                 raise ShellDBError(**exception)
@@ -107,7 +96,7 @@ class Shell:
                 raise server_exceptions.ConnectionError_
             else:
                 logger.exception(
-                    f"Failed to run MySQL Shell script:\n{logged_script}\n\nMySQL client error {e.code}\nMySQL Shell traceback:\n{e.traceback_message}\n"
+                    f"Failed to run MySQL Shell script:\n{script}\n\nMySQL client error {e.code}\nMySQL Shell traceback:\n{e.traceback_message}\n"
                 )
                 raise
 

--- a/src/mysql_shell/__init__.py
+++ b/src/mysql_shell/__init__.py
@@ -70,7 +70,8 @@ class Shell:
             self._container.run_mysql_shell(
                 [
                     "--passwords-from-stdin",
-                    f"--uri={self._connection_info.username}@{self._connection_info.host}:{self._connection_info.port}",
+                    "--uri",
+                    f"{self._connection_info.username}@{self._connection_info.host}:{self._connection_info.port}",
                     "--python",
                     "-c",
                     script,

--- a/src/mysql_shell/__init__.py
+++ b/src/mysql_shell/__init__.py
@@ -70,6 +70,7 @@ class Shell:
         temporary_script_file.write_text(script)
 
         try:
+            # https://bugs.mysql.com/bug.php?id=117429 details on why --no-wizard is omitted
             self._container.run_mysql_shell(
                 [
                     "--passwords-from-stdin",

--- a/src/mysql_shell/templates/try_except_wrapper.py.jinja
+++ b/src/mysql_shell/templates/try_except_wrapper.py.jinja
@@ -3,6 +3,7 @@ import mysqlsh
 import traceback
 
 try:
+    # Disable wizards in this script, since it will be invoked without --no-wizard
     shell.options.set('useWizards', False)
     {{ code|indent(width=4) }}
 except mysqlsh.DBError as exception:

--- a/src/mysql_shell/templates/try_except_wrapper.py.jinja
+++ b/src/mysql_shell/templates/try_except_wrapper.py.jinja
@@ -3,7 +3,7 @@ import mysqlsh
 import traceback
 
 try:
-    shell.connect("{{ username }}:{{ password }}@{{ host }}:{{ port }}")
+    shell.options.set('useWizards', False)
     {{ code|indent(width=4) }}
 except mysqlsh.DBError as exception:
     error = {


### PR DESCRIPTION
## Issue
We are storing passwords on disk (in the mysqlsh python script) when we execute mysqlsh. This is a security vulnerability

## Solution
Avoid writing passwords on disk, and instead use `--passwords-from-stdin` flag of mysqlsh
