### PR TITLE
Add default 30 second timeout to snap subprocess calls

### DIFF
--- a/src/container.py
+++ b/src/container.py
@@ -228,14 +228,11 @@ class Container(abc.ABC):
         self.create_router_rest_api_credentials_file()
 
         if not password:
-            users_credentials = self._run_command(
-                [
-                    self._mysql_router_password_command,
-                    "list",
-                    str(self.rest_api_credentials_file),
-                ],
-                timeout=30,
-            )
+            users_credentials = self._run_command([
+                self._mysql_router_password_command,
+                "list",
+                str(self.rest_api_credentials_file),
+            ])
             if user not in users_credentials:
                 return
 
@@ -248,5 +245,4 @@ class Container(abc.ABC):
                 user,
             ],
             input=password,
-            timeout=30,
         )

--- a/src/snap.py
+++ b/src/snap.py
@@ -256,7 +256,7 @@ class Snap(container.Container):
         self,
         command: typing.List[str],
         *,
-        timeout: typing.Optional[int],
+        timeout: typing.Optional[int] = 30,
         input: str = None,  # noqa: A002 Match subprocess.run()
     ) -> str:
         try:

--- a/src/workload.py
+++ b/src/workload.py
@@ -266,7 +266,7 @@ class AuthenticatedWorkload(Workload):
 
         command = self._get_bootstrap_command(event=event, connection_info=self._connection_info)
         try:
-            self._container.run_mysql_router(command, timeout=30)
+            self._container.run_mysql_router(command)
         except container.CalledProcessError as e:
             # Original exception contains password
             # Re-raising would log the password to Juju's debug log
@@ -327,7 +327,7 @@ class AuthenticatedWorkload(Workload):
 
     def _enable_router(self, *, event, tls: bool, unit_name: str) -> None:
         """Enable router after setting up all the necessary prerequisites."""
-        logger.debug("Enabling MySQL Router service")
+        logger.info("Enabling MySQL Router service")
         self._cleanup_after_upgrade_or_potential_container_restart()
         # create an empty credentials file, if the file does not exist
         self._container.create_router_rest_api_credentials_file()
@@ -337,7 +337,7 @@ class AuthenticatedWorkload(Workload):
         )
         self._container.update_mysql_router_service(enabled=True, tls=tls)
         self._logrotate.enable()
-        logger.debug("Enabled MySQL Router service")
+        logger.info("Enabled MySQL Router service")
         self._charm.wait_until_mysql_router_ready(event=event)
 
     def _enable_exporter(


### PR DESCRIPTION
Companion PR to https://github.com/canonical/mysql-router-k8s-operator/pull/394

Use 30 seconds instead of 15 since we aren't constrainted by Kubernetes pod `terminationGracePeriodSeconds`
