### PR TITLE
[MISC] Remove ubuntu@20.04 base

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -128,7 +128,7 @@ jobs:
         # Only upload results from one spread system & one spread variant
         # Allure can only process one result per pytest test ID. If parameterization is done via
         # spread instead of pytest, there will be overlapping pytest test IDs.
-        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:ubuntu-24.04:') && endsWith(matrix.job.spread_job, ':juju36_ubuntu22') && github.event_name == 'schedule' && github.run_attempt == '1' }}
+        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:ubuntu-24.04:') && github.event_name == 'schedule' && github.run_attempt == '1' }}
         uses: actions/upload-artifact@v4
         with:
           name: allure-results-integration-test-${{ matrix.job.name_in_artifact }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,7 +3,6 @@
 
 type: charm
 platforms:
-  ubuntu@20.04:amd64:
   ubuntu@22.04:amd64:
   ubuntu@22.04:arm64:
 # Files implicitly created by charmcraft without a part:

--- a/spread.yaml
+++ b/spread.yaml
@@ -94,9 +94,7 @@ backends:
       - ubuntu-24.04-arm:
           username: runner
           variants:
-            - -juju36_ubuntu20
             - -juju29_ubuntu22
-            - -juju29_ubuntu20
 
 suites:
   tests/spread/:
@@ -107,10 +105,9 @@ path: /root/spread_project
 kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
-  CONCIERGE_JUJU_CHANNEL/juju36_ubuntu22,juju36_ubuntu20: 3.6/stable
-  CONCIERGE_JUJU_CHANNEL/juju29_ubuntu22,juju29_ubuntu20: 2.9/stable
+  CONCIERGE_JUJU_CHANNEL/juju36_ubuntu22: 3.6/stable
+  CONCIERGE_JUJU_CHANNEL/juju29_ubuntu22: 2.9/stable
   CHARM_UBUNTU_BASE/juju36_ubuntu22,juju29_ubuntu22: 22.04
-  CHARM_UBUNTU_BASE/juju36_ubuntu20,juju29_ubuntu20: 20.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"


### PR DESCRIPTION
This PR temporarily removes `ubuntu20` base, as it currently fails to build due to [this problem](https://github.com/canonical/charmcraft/issues/2259), and is blocking PRs:

- https://github.com/canonical/mysql-router-operator/pull/241.
- https://github.com/canonical/mysql-router-operator/pull/249.
