### PR TITLE
[MISC] Pin grafana-agent channel to `1/stable`

### DIFF
--- a/tests/integration/test_exporter.py
+++ b/tests/integration/test_exporter.py
@@ -60,7 +60,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm, series) -> None:
             GRAFANA_AGENT_APP_NAME,
             application_name=GRAFANA_AGENT_APP_NAME,
             num_units=0,
-            channel="latest/stable",
+            channel="1/stable",
             series=series,
         ),
     )

--- a/tests/integration/test_exporter_with_tls.py
+++ b/tests/integration/test_exporter_with_tls.py
@@ -71,7 +71,7 @@ async def test_exporter_endpoint(ops_test: OpsTest, charm, series) -> None:
             GRAFANA_AGENT_APP_NAME,
             application_name=GRAFANA_AGENT_APP_NAME,
             num_units=0,
-            channel="latest/stable",
+            channel="1/stable",
             series=series,
         ),
     )


### PR DESCRIPTION
The Observability team removed the `latest/stable` track as of Friday June 20. Channels will now be prefixed by the charm major versions (i.e. `1/...`, `2/...`). See:

- June 20th: Last [CI run](https://github.com/canonical/mysql-router-operator/actions/runs/15769090923) where exporter integration tests passed.
- June 21th: First [CI run](https://github.com/canonical/mysql-router-operator/actions/runs/15790569479) where exporter integration tests failed.