### PR TITLE
Update charm-refresh to v3.1.0.0

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -7,9 +7,9 @@ pre-refresh-check:
 force-refresh-start:
   description: |
     Potential of data loss and downtime
-    
+
     Force refresh of first unit
-    
+
     Must run with at least one of the parameters `=false`
   params:
     check-compatibility:
@@ -17,42 +17,42 @@ force-refresh-start:
       default: true
       description: |
         Potential of data loss and downtime
-        
+
         If `false`, force refresh if new version of Router and/or charm is not compatible with previous version
     run-pre-refresh-checks:
       type: boolean
       default: true
       description: |
         Potential of data loss and downtime
-        
+
         If `false`, force refresh if app is unhealthy or not ready to refresh (and unit status shows "Pre-refresh check failed")
     check-workload-container:
       type: boolean
       default: true
       description: |
         Potential of data loss and downtime during and after refresh
-        
+
         If `false`, allow refresh to Router container version that has not been validated to work with the charm revision
   additionalProperties: false
 resume-refresh:
   description: |
     Refresh next unit(s) (after you have manually verified that refreshed units are healthy)
-    
-    If the `pause_after_unit_refresh` config is set to `all`, this action will refresh the next unit.
-    
-    If `pause_after_unit_refresh` is set to `first`, this action will refresh all remaining units.
+
+    If the `pause-after-unit-refresh` config is set to `all`, this action will refresh the next unit.
+
+    If `pause-after-unit-refresh` is set to `first`, this action will refresh all remaining units.
     Exception: if automatic health checks fail after a unit has refreshed, the refresh will pause.
-    
-    If `pause_after_unit_refresh` is set to `none`, this action will have no effect unless it is called with `check-health-of-refreshed-units` as `false`.
+
+    If `pause-after-unit-refresh` is set to `none`, this action will have no effect unless it is called with `check-health-of-refreshed-units` as `false`.
   params:
     check-health-of-refreshed-units:
       type: boolean
       default: true
       description: |
         Potential of data loss and downtime
-        
+
         If `false`, force refresh (of next unit) if 1 or more refreshed units are unhealthy
-        
+
         Warning: if first unit to refresh is unhealthy, consider running `force-refresh-start` action on that unit instead of using this parameter.
         If first unit to refresh is unhealthy because compatibility checks, pre-refresh checks, or workload container checks are failing, this parameter is more destructive than the `force-refresh-start` action.
   additionalProperties: false

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,7 @@ options:
     description: |
       Virtual IP to use to front mysql router units. Used only in case of external node connection.
     type: string
-  pause_after_unit_refresh:
+  pause-after-unit-refresh:
     description: |
       Wait for manual confirmation to resume refresh after these units refresh
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -398,14 +398,14 @@ charm-api = ">=0.1.1"
 
 [[package]]
 name = "charm-refresh"
-version = "3.0.0.8"
+version = "3.1.0.0"
 description = "In-place rolling refreshes (upgrades) of stateful charmed applications"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "charm_refresh-3.0.0.8-py3-none-any.whl", hash = "sha256:afa856144e6973e32759f46ca3bcf21d7743c0db8650407d0b482d0e67e51f71"},
-    {file = "charm_refresh-3.0.0.8.tar.gz", hash = "sha256:a29fa03d712a60b2140a50e7c22f558d5c0bb71e4ae48c27480c5113bb773bae"},
+    {file = "charm_refresh-3.1.0.0-py3-none-any.whl", hash = "sha256:c673077b56700bb255a05b81e215e6de042707f2037f84579ae513a48e37c80c"},
+    {file = "charm_refresh-3.1.0.0.tar.gz", hash = "sha256:20c61a4365d762fa8fd378b4e57312d94e7e52c9100bcf1ffdcbdefc68271467"},
 ]
 
 [package.dependencies]
@@ -2857,4 +2857,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "1be1edc953da1c385ebea70b489ee40e9e1e534fb60dcd4b9ddd3c9b3b704770"
+content-hash = "f2c411b5b151c44368a3417a9bc76d41225dfa08dd108ea2922f73f8bc72c667"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ tenacity = "^9.1.2"
 poetry-core = "^2.1.3"
 jinja2 = "^3.1.6"
 requests = "^2.32.4"
-charm-refresh = "^3.0.0.6"
+charm-refresh = "^3.1.0.0"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py


### PR DESCRIPTION
Followed instructions at https://chat.canonical.com/canonical/pl/wm3d1h6rhi8jumwmecyairoq7c

UI change: `pause_after_unit_refresh` renamed to `pause-after-unit-refresh`. Breaking change but no stable release currently exists